### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/refheap.el
+++ b/refheap.el
@@ -3,6 +3,7 @@
 ;;; Author: Anthony Grimes
 ;;; URL: https://github.com/Raynes/refheap.el
 ;;; Version: 0.0.3
+;;; Package-Requires: ((json "1.2"))
 
 (require 'json)
 (require 'url)


### PR DESCRIPTION
Adds a missing declaration for a dependency on the `json` package.

This is related to a request for MELPA to include this package: https://github.com/milkypostman/melpa/pull/951
